### PR TITLE
Jenkins baseline bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>1.609</jenkins.version>
+    <jenkins.version>1.642.1</jenkins.version>
     <java.level>7</java.level>
     <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
   </properties>


### PR DESCRIPTION
`workflow-multibranch:1.15` requires Jenkins 1.642.1, so this plugin requires it transitively.

@reviewbybees 
