### PR TITLE
Invalid scm-api version loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 target
 work
+.idea
 .project
 .settings
 .classpath
+github-organization-folder.iml

--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,18 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
       <version>1.3</version>
+      <exclusions>
+        <!-- It is github-branch-source who determines scm-api version -->
+        <exclusion>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>scm-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-branch-source</artifactId>
-      <version>1.3</version>
+      <version>1.4</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
To avoid this:

```
mar 31, 2016 5:16:28 PM hudson.model.Executor finish1 GRAVE: Executor threw an exception java.lang.NoSuchMethodError:
jenkins.scm.api.SCMSource.getTrustedRevision(Ljenkins/scm/api/SCMRevision;Lhudson/model/TaskListener;)Ljenkins/scm/api/SCMRevision; at
org.jenkinsci.plugins.workflow.multibranch.SCMBinder.create(SCMBinder.java:80) at
org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:206) at
hudson.model.ResourceController.execute(ResourceController.java:98) at
hudson.model.Executor.run(Executor.java:410)
```

`scm-api 1.0` was loaded transitively instead of `scm-api 1.1`

@reviewbybees especially @kohsuke and @jglick 
