### PR TITLE
Bump parent pom to 2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.3</version>
+    <version>2.11</version>
   </parent>
   <artifactId>github-organization-folder</artifactId>
   <version>1.4-SNAPSHOT</version>


### PR DESCRIPTION
Bump parent pom version to 2.11 to avoid potential `httpcomponents` issues.

@reviewbybees esp. @recena 
