### PR TITLE
[JENKINS-31155] Dynamic loader for GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,16 +5,15 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.11</version>
+    <version>2.14</version>
+    <relativePath/>
   </parent>
   <artifactId>github-organization-folder</artifactId>
   <version>1.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>1.642.1</jenkins.version>
-    <java.level>7</java.level>
-    <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
+    <jenkins.version>1.642.3</jenkins.version>
   </properties>
 
   <name>GitHub Organization Folder Plugin</name>
@@ -38,13 +37,13 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 
@@ -52,35 +51,52 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>5.8</version>
+      <version>5.12</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>scm-api</artifactId>
+      <version>1.3-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/scm-api-plugin/pull/12 -->
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <version>1.6</version>
-      <exclusions>
-        <!-- It is github-branch-source who determines scm-api version -->
-        <exclusion>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>scm-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-branch-source</artifactId>
-      <version>1.5</version>
+      <version>1.9</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-multibranch</artifactId>
+      <artifactId>workflow-step-api</artifactId>
       <version>2.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-aggregator</artifactId>
-      <version>1.15</version>
-      <scope>test</scope> <!-- TODO or do we want this as a runtime dep? -->
+      <artifactId>workflow-job</artifactId>
+      <version>2.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-scm-step</artifactId>
+      <version>2.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-multibranch</artifactId>
+      <version>2.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>2.13-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/45 -->
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps-global-lib</artifactId>
+      <version>2.3-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/10 -->
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>1.3-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/scm-api-plugin/pull/12 -->
+      <version>1.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -91,12 +91,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.14-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/45 -->
+      <version>2.14</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps-global-lib</artifactId>
-      <version>2.3-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/10 -->
+      <version>2.3</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <version>2.13-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/45 -->
+      <version>2.14-SNAPSHOT</version> <!-- TODO https://github.com/jenkinsci/workflow-cps-plugin/pull/45 -->
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/orgfolder/github/GitHubLibraryResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/orgfolder/github/GitHubLibraryResolver.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import jenkins.plugins.git.GitSCMSource;
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.LibraryResolver;
+import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
 
 /**
  * Allows libraries to be loaded on the fly from GitHub.
@@ -49,7 +50,7 @@ import org.jenkinsci.plugins.workflow.libs.LibraryResolver;
             if (entry.getKey().matches("github[.]com/([^/]+)/([^/]+)")) {
                 String name = entry.getKey();
                 // Currently GitHubSCMSource offers no particular advantage here over GitSCMSource.
-                LibraryConfiguration lib = new LibraryConfiguration(name, new GitSCMSource(null, "https://" + name + ".git", "", "*", "", true));
+                LibraryConfiguration lib = new LibraryConfiguration(name, new SCMSourceRetriever(new GitSCMSource(null, "https://" + name + ".git", "", "*", "", true)));
                 lib.setDefaultVersion("master");
                 libs.add(lib);
             }

--- a/src/main/java/org/jenkinsci/plugins/orgfolder/github/GitHubLibraryResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/orgfolder/github/GitHubLibraryResolver.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.orgfolder.github;
+
+import hudson.Extension;
+import hudson.model.Job;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import jenkins.plugins.git.GitSCMSource;
+import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
+import org.jenkinsci.plugins.workflow.libs.LibraryResolver;
+
+/**
+ * Allows libraries to be loaded on the fly from GitHub.
+ */
+@Extension public class GitHubLibraryResolver extends LibraryResolver {
+
+    @Override public boolean isTrusted() {
+        return false;
+    }
+
+    @Override public Collection<LibraryConfiguration> forJob(Job<?,?> job, Map<String,String> libraryVersions) {
+        List<LibraryConfiguration> libs = new ArrayList<>();
+        for (Map.Entry<String,String> entry : libraryVersions.entrySet()) {
+            if (entry.getKey().matches("github[.]com/([^/]+)/([^/]+)")) {
+                String name = entry.getKey();
+                // Currently GitHubSCMSource offers no particular advantage here over GitSCMSource.
+                LibraryConfiguration lib = new LibraryConfiguration(name, new GitSCMSource(null, "https://" + name + ".git", "", "*", "", true));
+                lib.setDefaultVersion("master");
+                libs.add(lib);
+            }
+        }
+        return libs;
+    }
+
+}


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/10. Allows for example

``` groovy
@Library('github.com/jglick/sample-pipeline-library') _
echo "changed there? ${currentBuildExt().hasChangeIn('some-folder')}"
```

to load https://github.com/jglick/sample-pipeline-library without any configuration in Jenkins.

Does not specifically need to be in this plugin, but I could not think of a more appropriate place.

@reviewbybees
