### PR TITLE
[JENKINS-39136] Remove CustomNameJobColumn

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/orgfolder/github/CustomNameJobColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/orgfolder/github/CustomNameJobColumn.java
@@ -16,66 +16,17 @@ import java.util.logging.Logger;
  * {@link JobColumn} with different caption
  *
  * @author Kohsuke Kawaguchi
+ * @deprecated use {@link com.cloudbees.hudson.plugins.folder.views.CustomNameJobColumn}
  */
-public class CustomNameJobColumn extends JobColumn {
-    /**
-     * Resource bundle name.
-     */
-    private final String bundle;
-    private final String key;
+@Deprecated
+public class CustomNameJobColumn extends com.cloudbees.hudson.plugins.folder.views.CustomNameJobColumn {
 
-    private transient Localizable loc;
-
-    @DataBoundConstructor
-    public CustomNameJobColumn(String bundle, String key) {
-        this.bundle = bundle;
-        this.key = key;
-        readResolve();
-    }
-
-    public CustomNameJobColumn(Class bundle, Localizable loc) {
-        this.bundle = bundle.getName();
-        this.key = loc.getKey();
-        this.loc = loc;
+    private CustomNameJobColumn(String bundle, String key) {
+        super(bundle, key);
     }
 
     private Object readResolve() {
-        try {
-            loc = new Localizable(
-                ResourceBundleHolder.get(Jenkins.getActiveInstance().pluginManager.uberClassLoader.loadClass(bundle)),
-                key);
-        } catch (ClassNotFoundException e) {
-            LOGGER.log(Level.WARNING, "No such bundle: "+bundle);
-            loc = new NonLocalizable(bundle+':'+key);
-        }
-        return this;
+        return new com.cloudbees.hudson.plugins.folder.views.CustomNameJobColumn(getBundle(), getKey());
     }
 
-
-    public String getBundle() {
-        return bundle;
-    }
-
-    public String getKey() {
-        return key;
-    }
-
-    public String getMessage() {
-        return loc.toString();
-    }
-
-    @Extension
-    public static class DescriptorImpl extends ListViewColumnDescriptor {
-        @Override
-        public String getDisplayName() {
-            return "Job Name with Custom Title";
-        }
-
-        @Override
-        public boolean shownByDefault() {
-            return false;
-        }
-    }
-
-    private static final Logger LOGGER = Logger.getLogger(CustomNameJobColumn.class.getName());
 }

--- a/src/main/java/org/jenkinsci/plugins/orgfolder/github/CustomNameJobColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/orgfolder/github/CustomNameJobColumn.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.orgfolder.github;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.views.JobColumn;
 import hudson.views.ListViewColumnDescriptor;
@@ -19,6 +20,7 @@ import java.util.logging.Logger;
  * @deprecated use {@link com.cloudbees.hudson.plugins.folder.views.CustomNameJobColumn}
  */
 @Deprecated
+@SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
 public class CustomNameJobColumn extends com.cloudbees.hudson.plugins.folder.views.CustomNameJobColumn {
 
     private CustomNameJobColumn(String bundle, String key) {

--- a/src/main/java/org/jenkinsci/plugins/orgfolder/github/CustomNameJobColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/orgfolder/github/CustomNameJobColumn.java
@@ -1,34 +1,18 @@
 package org.jenkinsci.plugins.orgfolder.github;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.Extension;
 import hudson.views.JobColumn;
-import hudson.views.ListViewColumnDescriptor;
-import jenkins.model.Jenkins;
-import jenkins.util.NonLocalizable;
-import org.jvnet.localizer.Localizable;
-import org.jvnet.localizer.ResourceBundleHolder;
-import org.kohsuke.stapler.DataBoundConstructor;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * {@link JobColumn} with different caption
  *
  * @author Kohsuke Kawaguchi
- * @deprecated use {@link com.cloudbees.hudson.plugins.folder.views.CustomNameJobColumn}
+ * @deprecated use {@link JobColumn}
  */
 @Deprecated
-@SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
-public class CustomNameJobColumn extends com.cloudbees.hudson.plugins.folder.views.CustomNameJobColumn {
-
-    private CustomNameJobColumn(String bundle, String key) {
-        super(bundle, key);
-    }
+public class CustomNameJobColumn extends JobColumn {
 
     private Object readResolve() {
-        return new com.cloudbees.hudson.plugins.folder.views.CustomNameJobColumn(getBundle(), getKey());
+        return new JobColumn();
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/orgfolder/github/MainLogic.java
+++ b/src/main/java/org/jenkinsci/plugins/orgfolder/github/MainLogic.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.orgfolder.github;
 
+import com.cloudbees.hudson.plugins.folder.views.CustomNameJobColumn;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import hudson.BulkChange;
 import hudson.Extension;

--- a/src/main/java/org/jenkinsci/plugins/orgfolder/github/MainLogic.java
+++ b/src/main/java/org/jenkinsci/plugins/orgfolder/github/MainLogic.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.orgfolder.github;
 
-import com.cloudbees.hudson.plugins.folder.views.CustomNameJobColumn;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import hudson.BulkChange;
 import hudson.Extension;
@@ -85,7 +84,7 @@ public class MainLogic {
                     lv.getColumns().replaceBy(asList(
                         new StatusColumn(),
                         new WeatherColumn(),
-                        new CustomNameJobColumn(Messages.class,Messages._ListViewColumn_Repository()),
+                        new JobColumn(),
                         new GitHubRepositoryDescriptionColumn()
                     ));
                     lv.setIncludeRegex(".*");   // show all
@@ -143,17 +142,9 @@ public class MainLogic {
                 if (item.getView("Branches")==null && item.getView("All") instanceof AllView) {
                     // create initial views
                     ListView bv = new ListView("Branches");
-                    DescribableList<ListViewColumn, Descriptor<ListViewColumn>> cols = bv.getColumns();
-                    JobColumn name = cols.get(JobColumn.class);
-                    if (name!=null)
-                        cols.replace(name,new CustomNameJobColumn(Messages.class, Messages._ListViewColumn_Branch()));
                     bv.getJobFilters().add(new GitHubBranchFilter());
 
                     ListView pv = new ListView("Pull Requests");
-                    cols = pv.getColumns();
-                    name = cols.get(JobColumn.class);
-                    if (name!=null)
-                        cols.replace(name,new CustomNameJobColumn(Messages.class, Messages._ListViewColumn_PullRequest()));
                     pv.getJobFilters().add(new GitHubPullRequestFilter());
 
                     item.addView(bv);


### PR DESCRIPTION
"Name" is perfectly acceptable compared with the confusion for users in the general view configuration as to what the new custom job name column is, and how to configure it and what the message bundle and key mean.

![screen shot 2016-10-21 at 10 59 43](https://cloud.githubusercontent.com/assets/209336/19594780/a2f0ceae-977e-11e6-8bf7-4a046f20790d.png)
![screen shot 2016-10-21 at 10 59 53](https://cloud.githubusercontent.com/assets/209336/19594786/a57e4994-977e-11e6-8866-1a6c15143d2d.png)
![screen shot 2016-10-21 at 10 59 59](https://cloud.githubusercontent.com/assets/209336/19594791/a91229cc-977e-11e6-9e4f-36bb50c13587.png)

@reviewbybees 

[JENKINS-39167](https://issues.jenkins-ci.org/browse/JENKINS-39167) created to restore the equivalent functionality through a change in Jenkins core
